### PR TITLE
Switch xt_app to eframe bootstrap

### DIFF
--- a/crates/xt_app/Cargo.toml
+++ b/crates/xt_app/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 
 [dependencies]
 dioxus = { version = "0.7.1", features = ["router", "fullstack"] }
+eframe = "0.29.1"
+egui = "0.29.1"
 xt_core = { path = "../xt_core" }
 
 [features]

--- a/crates/xt_app/src/main.rs
+++ b/crates/xt_app/src/main.rs
@@ -1,5 +1,6 @@
 use dioxus::html::HasFileData;
 use dioxus::prelude::*;
+use eframe::egui;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -145,26 +146,28 @@ enum SpacerPosition {
     Bottom,
 }
 
-fn main() {
-    #[cfg(all(
-        feature = "desktop",
-        any(target_os = "windows", target_os = "linux", target_os = "macos")
-    ))]
-    {
-        use dioxus::desktop::Config;
-        dioxus::LaunchBuilder::new()
-            .with_cfg(Config::new().with_menu(build_native_menu()))
-            .launch(App);
+fn main() -> eframe::Result<()> {
+    let options = eframe::NativeOptions::default();
+    eframe::run_native(
+        "xtrans-rs",
+        options,
+        Box::new(|_cc| Ok(Box::new(App::default()))),
+    )
+}
+
+#[derive(Default)]
+struct App;
+
+impl eframe::App for App {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.label("xtrans-rs を eframe で起動しました。");
+        });
     }
-    #[cfg(not(all(
-        feature = "desktop",
-        any(target_os = "windows", target_os = "linux", target_os = "macos")
-    )))]
-    dioxus::launch(App);
 }
 
 #[component]
-fn App() -> Element {
+fn DioxusApp() -> Element {
     let mut history = use_signal(|| UndoStack::new(Vec::new()));
     let mut state = use_signal(|| TwoPaneState::new(history.read().present().clone()));
 


### PR DESCRIPTION
### Motivation

- デスクトップ起動処理を Dioxus のランチャーから `eframe::run_native` に移行して、まずは既存の Dioxus UI を使わずに最小の `eframe::App` で起動できる状態を作るため。

### Description

- `crates/xt_app/Cargo.toml` に `eframe` と `egui` を追加して依存関係を導入しました。
- `crates/xt_app/src/main.rs` の `main` を `eframe::run_native` を使う実装に置き換え、最小の `eframe::App` 構造体と `impl eframe::App` を追加しました。
- 既存の Dioxus ルートコンポーネント `App` を `DioxusApp` に改名して残し、Dioxus 側のコードは当面そのまま利用できるようにしました。
- `use eframe::egui` を追加して `egui` API を使用するようにし、画面には簡易ラベル `"xtrans-rs を eframe で起動しました。"` を表示します。

### Testing

- 自動テストは実行していません（ビルドや `cargo test` の実行は行っていません）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69888a99cdcc83238a151bcac38b87d3)