### PR TITLE
RefactorMenuHandling

### DIFF
--- a/crates/xt_app/assets/main.css
+++ b/crates/xt_app/assets/main.css
@@ -17,12 +17,13 @@ body {
 #app-shell {
     height: 100vh;
     display: grid;
-    grid-template-rows: 40px 48px 1fr 40px 250px 30px;
+    grid-template-rows: 32px 40px 48px 1fr 40px 250px 30px;
     background: var(--bg);
     border: 1px solid #9d9d9d;
     box-sizing: border-box;
 }
 
+.menu-bar,
 .toolbar,
 .channels,
 .tabs,
@@ -54,6 +55,39 @@ body {
     background: var(--panel);
     border-bottom: 1px solid var(--line);
     gap: 6px;
+}
+
+.menu-bar {
+    background: #f7f7f7;
+    border-bottom: 1px solid var(--line);
+    gap: 16px;
+    font-size: 12px;
+    flex-wrap: wrap;
+}
+
+.menu-group {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.menu-label {
+    font-weight: 600;
+    color: #2f2f2f;
+}
+
+.menu-item {
+    border: 1px solid #a2a2a2;
+    background: #ffffff;
+    color: var(--text);
+    height: 24px;
+    padding: 0 8px;
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.menu-item:hover {
+    background: #dfeeff;
 }
 
 .tool-ic {
@@ -281,7 +315,7 @@ body {
 
 @media (max-width: 1100px) {
     #app-shell {
-        grid-template-rows: 34px 42px 1fr 36px 240px 30px;
+        grid-template-rows: 30px 34px 42px 1fr 36px 240px 30px;
     }
 
     .grid-head,


### PR DESCRIPTION
### Motivation
- ネイティブデスクトップのメニュー (`muda`/`use_muda_event_handler`) とグローバルショートカット周りの結合を解消して、アプリ内で一元管理するための移行を行いました。 
- 将来的な方針としては `winit` のイベントハンドラや OS 依存の `global-hotkey` 等でグローバルショートカットを再導入する選択肢を検討できる設計にしています。

### Description
- 新しく `MenuAction` 列挙型と `MenuContext` 構造体を導入し、メニュー操作をシグナル群に対する共通ハンドラ `MenuContext::handle` に集約しました。 
- ネイティブメニュー生成の `build_native_menu` と `use_muda_event_handler` / `use_global_shortcut` による外部メニュー・ショートカット登録処理を削除し、代わりにアプリ内 RSX ベースのメニューバー（`div`/`button`）を `App` に追加して `menu_ctx.handle(...)` で操作を呼び出すようにしました。 
- レイアウトを上部メニューバー分に合わせて `assets/main.css` を更新し、`#app-shell` の `grid-template-rows` と新しい `.menu-bar` / `.menu-group` / `.menu-item` スタイルを追加しました。 
- `dioxus::LaunchBuilder` の呼び出しでネイティブメニュー設定 (`with_menu`) を使わず起動するように修正しました。

### Testing
- この環境では自動化テストは実行しておらず、`dx` コマンドが存在しないためデスクトップ起動／手動 UI 確認は実行できませんでした (テスト未実行)。 
- CI/ローカルでの検証としては少なくとも `cargo build -p xt_app` と `dx serve --platform desktop` の起動確認を推奨します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69888aa8b928832390b4ae1e1e87c49f)