### PR TITLE
AlignVirtualListWithEguiShowRows

### DIFF
--- a/crates/xt_app/src/main.rs
+++ b/crates/xt_app/src/main.rs
@@ -24,7 +24,7 @@ use xt_core::validation::{
     validate_alias_tags, validate_braced_placeholders, validate_printf_placeholders,
     ValidationIssue,
 };
-use xt_core::virtual_list::{virtual_window, VirtualWindow};
+use xt_core::virtual_list::{show_rows_window, VirtualWindow};
 
 const FAVICON: Asset = asset!("/assets/favicon.ico");
 const MAIN_CSS: Asset = asset!("/assets/main.css");
@@ -393,13 +393,16 @@ fn App() -> Element {
         let snapshot = filtered_snapshot.read();
         snapshot.entries.len()
     };
-    let window = virtual_window(
+    let window = show_rows_window(
         filtered_len,
         item_height,
         *viewport_height.read(),
         *scroll_offset.read(),
         overscan,
     );
+    let render_start = if window.end > 0 { window.start + 1 } else { 0 };
+    let render_end = window.end;
+    let render_rows = window.len();
     let rows = {
         let snapshot = filtered_snapshot.read();
         snapshot
@@ -548,6 +551,9 @@ fn App() -> Element {
                     span { class: "c-src", "原文" }
                     span { class: "c-dst", "訳文" }
                     span { class: "c-ld", "LD" }
+                }
+                div { class: "grid-meta",
+                    "描画中: {render_start}-{render_end} / {filtered_len} (rows {render_rows})"
                 }
                 div {
                     class: "grid-body",


### PR DESCRIPTION
### Motivation
- `virtual_window` の可視行計算を `egui::ScrollArea::show_rows` に合わせて整合させ、`scroll_offset`/`viewport_height`/`item_height` の計算を egui と同じ振る舞いにしたい。
- 可視レンジの算出を変更すると同時に、描画負荷が簡単に確認できるよう UI 側でレンジ情報を表示したい。

### Description
- `crates/xt_core/src/virtual_list.rs` に `show_rows_window` を追加し、`egui::ScrollArea::show_rows` に合わせた行範囲計算を実装し、既存の `virtual_window` はこの関数へ委譲するようにしました（境界処理・overscan の扱いを調整）。
- `crates/xt_app/src/main.rs` で `virtual_window` の呼び出しを `show_rows_window` に置き換え、レンダリング対象の開始・終了行と行数を UI 上に `描画中: {start}-{end} / {filtered_len} (rows {render_rows})` として表示するようにしました（`scroll_offset`/`viewport_height` の読み取りは従来通り）。
- `crates/xt_core/src/virtual_list.rs` のユニットテストを新しい範囲計算に合わせて修正しました。

### Testing
- 自動テストは実行していません（今回の差分ではテスト実行は実施されていません）。
- `crates/xt_core/src/virtual_list.rs` のユニットテストは更新済みですが、この環境で `cargo test` を実行しての確認は行っていません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69888aac33688323a3f253ac625694b7)