### PR TITLE
Use egui TextEdit for editor inputs

### DIFF
--- a/crates/xt_app/Cargo.toml
+++ b/crates/xt_app/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 dioxus = { version = "0.7.1", features = ["router", "fullstack"] }
+egui = "0.28.1"
 xt_core = { path = "../xt_core" }
 
 [features]


### PR DESCRIPTION
### Motivation

- 既存の `input` / `textarea` によるテキスト編集 UI を、`egui::TextEdit::singleline` / `multiline` ベースの同等 UI に置き換えて、egui の `Response` を使った更新検知へ移行するための変更です。 

### Description

- `egui` 依存を `crates/xt_app/Cargo.toml` に追加しました。 
- `run_egui_text_edit` ヘルパー関数と、`EguiTextEditSingleline` / `EguiTextEditMultiline` コンポーネントを `crates/xt_app/src/main.rs` に追加し、`EguiContext` と `EguiResponse.changed()` に基づく更新（`on_change` コールバック呼び出し）を実装しました。 
- 検索フィールド、エディタ内の原文/訳文テキスト、辞書設定フィールド、XML テキスト領域などで既存の `input` / `textarea` を新しい egui ベースのコンポーネントに置き換え、既存の更新ロジックを `oninput` イベントから `on_change`（egui のレスポンス）へ移行しました。 
- `App` 内で `use_context_provider(|| EguiContext::default())` を追加し、egui コンテキストを提供して既存のスタイリング用に `id` / `class` を受け渡すようにしました。 

### Testing

- 自動化されたテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69888aa524ac8323a3d7e0b5aae897b0)